### PR TITLE
Set offset to 1 in PNDMScheduler

### DIFF
--- a/stable_diffusion_jax/pipeline_stable_diffusion.py
+++ b/stable_diffusion_jax/pipeline_stable_diffusion.py
@@ -46,7 +46,7 @@ class StableDiffusionPipeline:
         debug: bool = False,
     ):
 
-        self.scheduler.set_timesteps(num_inference_steps)
+        self.scheduler.set_timesteps(num_inference_steps, offset=1)
 
         text_embeddings = self.text_encoder(input_ids, params=inference_state.text_encoder_params)[0]
         uncond_embeddings = self.text_encoder(uncond_input_ids, params=inference_state.text_encoder_params)[0]


### PR DESCRIPTION
As in the PyTorch version.
This is only appropriate for `PNDMScheduler`, will have to be revisited when we add more.

This does not fix all the differences between Flax and PyTorch.