### PR TITLE
Fix off-by-one scheduler iteration

### DIFF
--- a/stable_diffusion_jax/pipeline_stable_diffusion.py
+++ b/stable_diffusion_jax/pipeline_stable_diffusion.py
@@ -81,12 +81,13 @@ class StableDiffusionPipeline:
             latents = self.scheduler.step(noise_pred, t, latents)["prev_sample"]
             return latents
 
+        scheduler_steps = len(self.scheduler.timesteps)     # num_inference_steps + 1
         if debug:
             # run with python for loop
-            for i in range(num_inference_steps):
+            for i in range(scheduler_steps):
                 latents = loop_body(i, latents)
         else:
-            latents = jax.lax.fori_loop(0, num_inference_steps, loop_body, latents)
+            latents = jax.lax.fori_loop(0, scheduler_steps, loop_body, latents)
 
         # scale and decode the image latents with vae
         latents = 1 / 0.18215 * latents


### PR DESCRIPTION
The scheduler actually provides 51 `timesteps` when setting `num_inference_steps` to 50.

PyTorch reference: https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py#L136
