### PR TITLE
Stateless scheduler

### DIFF
--- a/stable_diffusion_jax/pipeline_stable_diffusion.py
+++ b/stable_diffusion_jax/pipeline_stable_diffusion.py
@@ -5,7 +5,7 @@ import jax.numpy as jnp
 from PIL import Image
 from transformers import CLIPTokenizer, FlaxCLIPTextModel
 
-from stable_diffusion_jax.scheduling_pndm import PNDMScheduler
+from stable_diffusion_jax.scheduling_pndm import PNDMSchedulerState
 
 
 @flax.struct.dataclass
@@ -13,6 +13,7 @@ class InferenceState:
     text_encoder_params: flax.core.FrozenDict
     unet_params: flax.core.FrozenDict
     vae_params: flax.core.FrozenDict
+    scheduler_state: PNDMSchedulerState
 
 
 class StableDiffusionPipeline:
@@ -41,13 +42,9 @@ class StableDiffusionPipeline:
         uncond_input_ids: jnp.ndarray,
         prng_seed: jax.random.PRNGKey,
         inference_state: InferenceState,
-        num_inference_steps: int = 50,
         guidance_scale: float = 1.0,
         debug: bool = False,
     ):
-
-        self.scheduler.set_timesteps(num_inference_steps)
-
         text_embeddings = self.text_encoder(input_ids, params=inference_state.text_encoder_params)[0]
         uncond_embeddings = self.text_encoder(uncond_input_ids, params=inference_state.text_encoder_params)[0]
         context = jnp.concatenate([uncond_embeddings, text_embeddings])
@@ -60,13 +57,14 @@ class StableDiffusionPipeline:
         )
         latents = jax.random.normal(prng_seed, shape=latents_shape, dtype=jnp.float32)
 
-        def loop_body(step, latents):
+        def loop_body(step, args):
+            latents, scheduler_state = args
             # For classifier free guidance, we need to do two forward passes.
             # Here we concatenate the unconditional and text embeddings into a single batch
             # to avoid doing two forward passes
             latents_input = jnp.concatenate([latents] * 2)
 
-            t = jnp.array(self.scheduler.timesteps)[step]
+            t = jnp.array(scheduler_state.timesteps, dtype=jnp.int32)[step]
             timestep = jnp.broadcast_to(t, latents_input.shape[0])
 
             # predict the noise residual
@@ -78,15 +76,18 @@ class StableDiffusionPipeline:
             noise_pred = noise_pred_uncond + guidance_scale * (noise_prediction_text - noise_pred_uncond)
 
             # compute the previous noisy sample x_t -> x_t-1
-            latents = self.scheduler.step(noise_pred, t, latents)["prev_sample"]
-            return latents
+            latents, scheduler_state = self.scheduler.step(scheduler_state, noise_pred, t, latents)
+            latents = latents["prev_sample"]
+            return latents, scheduler_state
 
+        scheduler_state = inference_state.scheduler_state
+        num_inference_steps = len(scheduler_state.timesteps)
         if debug:
             # run with python for loop
             for i in range(num_inference_steps):
-                latents = loop_body(i, latents)
+                latents, scheduler_state = loop_body(i, (latents, scheduler_state))
         else:
-            latents = jax.lax.fori_loop(0, num_inference_steps, loop_body, latents)
+            latents, _ = jax.lax.fori_loop(0, num_inference_steps, loop_body, (latents, scheduler_state))
 
         # scale and decode the image latents with vae
         latents = 1 / 0.18215 * latents

--- a/stable_diffusion_jax/scheduling_pndm.py
+++ b/stable_diffusion_jax/scheduling_pndm.py
@@ -14,13 +14,17 @@
 
 # DISCLAIMER: This file is strongly influenced by https://github.com/ermongroup/ddim
 
+from dataclasses import dataclass
 import math
 
+import jax
 import jax.numpy as jnp
-import numpy as np
 from diffusers.configuration_utils import ConfigMixin, register_to_config
 from diffusers.schedulers.scheduling_utils import SchedulerMixin
 
+import flax
+
+from typing import Optional, Tuple
 
 def betas_for_alpha_bar(num_diffusion_timesteps, max_beta=0.999):
     """
@@ -45,6 +49,56 @@ def betas_for_alpha_bar(num_diffusion_timesteps, max_beta=0.999):
     return jnp.array(betas, dtype=jnp.float32)
 
 
+@flax.struct.dataclass
+class PNDMSchedulerState:
+    betas: jnp.array
+    num_train_timesteps: int
+
+    num_inference_steps: Optional[int]
+    _timesteps: jnp.array
+    _offset: int
+    prk_timesteps: Optional[jnp.array]
+    plms_timesteps: Optional[jnp.array]
+    timesteps: Optional[jnp.array]
+    
+    # running values
+    counter: int
+    model_output: jnp.array
+    sample: jnp.array
+    ets: jnp.array
+
+    # For now we only support F-PNDM, i.e. the runge-kutta method
+    # For more information on the algorithm please take a look at the paper: https://arxiv.org/pdf/2202.09778.pdf
+    # mainly at formula (9), (12), (13) and the Algorithm 2.
+    pndm_order = 4
+
+    @property
+    def alphas(self) -> jnp.array:
+        return 1.0 - self.betas
+
+    @property
+    def alphas_cumprod(self) -> jnp.array:
+        return jnp.cumprod(self.alphas, axis=0)
+
+    @classmethod
+    def create(cls, betas: jnp.array, num_train_timesteps: int):
+        state = cls(
+            betas=betas,
+            num_train_timesteps=num_train_timesteps,
+            num_inference_steps = None,
+            _timesteps = jnp.arange(0, num_train_timesteps)[::-1].copy(),
+            _offset = 0,
+            prk_timesteps = None,
+            plms_timesteps = None,
+            timesteps = None,
+            counter = 0,
+            model_output = jnp.array([]),
+            sample = jnp.array([]),
+            ets = jnp.array([]),
+        )
+        return state
+
+    
 class PNDMScheduler(SchedulerMixin, ConfigMixin):
     @register_to_config
     def __init__(
@@ -58,125 +112,90 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
     ):
 
         if beta_schedule == "linear":
-            self.betas = jnp.linspace(beta_start, beta_end, num_train_timesteps, dtype=jnp.float32)
+            betas = jnp.linspace(beta_start, beta_end, num_train_timesteps, dtype=jnp.float32)
         elif beta_schedule == "scaled_linear":
             # this schedule is very specific to the latent diffusion model.
-            self.betas = jnp.linspace(beta_start**0.5, beta_end**0.5, num_train_timesteps, dtype=jnp.float32) ** 2
+            betas = jnp.linspace(beta_start**0.5, beta_end**0.5, num_train_timesteps, dtype=jnp.float32) ** 2
         elif beta_schedule == "squaredcos_cap_v2":
             # Glide cosine schedule
-            self.betas = betas_for_alpha_bar(num_train_timesteps)
+            betas = betas_for_alpha_bar(num_train_timesteps)
         else:
             raise NotImplementedError(f"{beta_schedule} does is not implemented for {self.__class__}")
 
-        self.alphas = 1.0 - self.betas
-        self.alphas_cumprod = jnp.cumprod(self.alphas, axis=0)
-
-        self.one = jnp.array(1.0)
-
-        # For now we only support F-PNDM, i.e. the runge-kutta method
-        # For more information on the algorithm please take a look at the paper: https://arxiv.org/pdf/2202.09778.pdf
-        # mainly at formula (9), (12), (13) and the Algorithm 2.
-        self.pndm_order = 4
-
-        # running values
-        self.cur_model_output = 0
-        self.counter = 0
-        self.cur_sample = None
-        self.ets = []
-
-        # setable values
-        self.num_inference_steps = None
-        self._timesteps = jnp.arange(0, num_train_timesteps)[::-1].copy()
-        self._offset = 0
-        self.prk_timesteps = None
-        self.plms_timesteps = None
-        self.timesteps = None
+        # Temporarily stored here, should be returned
+        self.state = PNDMSchedulerState.create(betas, num_train_timesteps)
 
         self.tensor_format = tensor_format
         self.set_format(tensor_format=tensor_format)
 
-    def set_timesteps(self, num_inference_steps, offset=0):
-        self.num_inference_steps = num_inference_steps
+    def set_timesteps(
+        self,
+        state: PNDMSchedulerState,
+        shape: Tuple,
+        num_inference_steps: int,
+        offset=0,
+    ) -> PNDMSchedulerState:
         # self._timesteps = list(
         #     range(0, self.config.num_train_timesteps, self.config.num_train_timesteps // num_inference_steps)
         # )
-        self._timesteps = jnp.arange(
+        _timesteps = jnp.arange(
             0, self.config.num_train_timesteps, self.config.num_train_timesteps // num_inference_steps
         )
-        self._offset = offset
         # self._timesteps = [t + self._offset for t in self._timesteps]
-        self._timesteps = self._timesteps + self._offset
+        _timesteps = _timesteps + offset
+        
+        state = state.replace(
+            num_inference_steps=num_inference_steps,
+            _offset=offset,
+            _timesteps=_timesteps,
+        )
 
         if self.config.skip_prk_steps:
             # for some models like stable diffusion the prk steps can/should be skipped to
             # produce better results. When using PNDM with `self.config.skip_prk_steps` the implementation
             # is based on crowsonkb's PLMS sampler implementation: https://github.com/CompVis/latent-diffusion/pull/51
-            self.prk_timesteps = jnp.array([])
-            # self.plms_timesteps = list(reversed(self._timesteps[:-1] + self._timesteps[-2:-1] + self._timesteps[-1:]))
-            self.plms_timesteps = jnp.concatenate(
-                (self._timesteps[:-1], self._timesteps[-2:-1], self._timesteps[-1:])
-            )[::-1]
-        else:
-            prk_timesteps = self._timesteps[-self.pndm_order :].repeat(2) + jnp.tile(
-                jnp.array([0, self.config.num_train_timesteps // num_inference_steps // 2]), self.pndm_order
+            state = state.replace(
+                prk_timesteps = jnp.array([]),
+                plms_timesteps = jnp.concatenate(
+                    (state._timesteps[:-1], state._timesteps[-2:-1], state._timesteps[-1:])
+                )[::-1]
             )
-            self.prk_timesteps = prk_timesteps[:-1].repeat(2)[1:-1][::-1]
-            self.plms_timesteps = self._timesteps[:-3][::-1]
+        else:
+            prk_timesteps = state._timesteps[-state.pndm_order :].repeat(2) + jnp.tile(
+                jnp.array([0, self.config.num_train_timesteps // num_inference_steps // 2]), state.pndm_order
+            )
+            state = state.replace(
+                prk_timesteps = prk_timesteps[:-1].repeat(2)[1:-1][::-1],
+                plms_timesteps = state._timesteps[:-3][::-1],
+            )
 
-        timesteps = jnp.concatenate((self.prk_timesteps, self.plms_timesteps))
-        self.timesteps = jnp.array(timesteps, dtype=jnp.int32)
+        timesteps = jnp.concatenate((state.prk_timesteps, state.plms_timesteps))
 
-        self.ets = []
-        self.counter = 0
+        state = state.replace(
+            timesteps = jnp.array(timesteps, dtype=jnp.int32),
+            counter = 0,
+            # Will be zeros, not really empty
+            model_output = jnp.empty(shape),
+            sample = jnp.empty(shape),
+            ets = jnp.empty((4,) + shape),
+        )
         self.set_format(tensor_format=self.tensor_format)
+
+        return state
 
     def step(
         self,
+        state: PNDMSchedulerState,
         model_output: jnp.ndarray,
         timestep: int,
         sample: jnp.ndarray,
     ):
-        if self.counter < len(self.prk_timesteps) and not self.config.skip_prk_steps:
-            return self.step_prk(model_output=model_output, timestep=timestep, sample=sample)
-        else:
-            return self.step_plms(model_output=model_output, timestep=timestep, sample=sample)
-
-    def step_prk(
-        self,
-        model_output: jnp.ndarray,
-        timestep: int,
-        sample: jnp.ndarray,
-    ):
-        """
-        Step function propagating the sample with the Runge-Kutta method. RK takes 4 forward passes to approximate the
-        solution to the differential equation.
-        """
-        diff_to_prev = 0 if self.counter % 2 else self.config.num_train_timesteps // self.num_inference_steps // 2
-        prev_timestep = max(timestep - diff_to_prev, self.prk_timesteps[-1])
-        timestep = self.prk_timesteps[self.counter // 4 * 4]
-
-        if self.counter % 4 == 0:
-            self.cur_model_output += 1 / 6 * model_output
-            self.ets.append(model_output)
-            self.cur_sample = sample
-        elif (self.counter - 1) % 4 == 0:
-            self.cur_model_output += 1 / 3 * model_output
-        elif (self.counter - 2) % 4 == 0:
-            self.cur_model_output += 1 / 3 * model_output
-        elif (self.counter - 3) % 4 == 0:
-            model_output = self.cur_model_output + 1 / 6 * model_output
-            self.cur_model_output = 0
-
-        # cur_sample should not be `None`
-        cur_sample = self.cur_sample if self.cur_sample is not None else sample
-
-        prev_sample = self._get_prev_sample(cur_sample, timestep, prev_timestep, model_output)
-        self.counter += 1
-
-        return {"prev_sample": prev_sample}
+        # TODO: restore `step_prk` when it is made stateless.
+        return self.step_plms(state=state, model_output=model_output, timestep=timestep, sample=sample)
 
     def step_plms(
         self,
+        state: PNDMSchedulerState,
         model_output: jnp.ndarray,
         timestep: int,
         sample: jnp.ndarray,
@@ -185,7 +204,7 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
         Step function propagating the sample with the linear multi-step method. This has one forward pass with multiple
         times to approximate the solution.
         """
-        if not self.config.skip_prk_steps and len(self.ets) < 3:
+        if not self.config.skip_prk_steps and len(state.ets) < 3:
             raise ValueError(
                 f"{self.__class__} can only be run AFTER scheduler has been run "
                 "in 'prk' mode for at least 12 iterations "
@@ -193,7 +212,7 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
                 "for more information."
             )
 
-        prev_timestep = timestep - self.config.num_train_timesteps // self.num_inference_steps
+        prev_timestep = timestep - self.config.num_train_timesteps // state.num_inference_steps
         prev_timestep = jnp.where(prev_timestep > 0, prev_timestep, 0)
 
         # Reference:
@@ -275,12 +294,18 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
         model_output = state.model_output
         prev_sample = self._get_prev_sample(state, sample, timestep, prev_timestep, model_output)
 
-        prev_sample = self._get_prev_sample(sample, timestep, prev_timestep, model_output)
-        self.counter += 1
+        state = state.replace(counter = state.counter + 1)
 
-        return {"prev_sample": prev_sample}
+        return {"prev_sample": prev_sample}, state
 
-    def _get_prev_sample(self, sample, timestep, timestep_prev, model_output):
+    def _get_prev_sample(
+        self,
+        state: PNDMSchedulerState,
+        sample,
+        timestep,
+        timestep_prev,
+        model_output
+    ):
         # See formula (9) of PNDM paper https://arxiv.org/pdf/2202.09778.pdf
         # this function computes x_(t−δ) using the formula of (9)
         # Note that x_t needs to be added to both sides of the equation
@@ -293,8 +318,8 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
         # sample -> x_t
         # model_output -> e_θ(x_t, t)
         # prev_sample -> x_(t−δ)
-        alpha_prod_t = self.alphas_cumprod[timestep + 1 - self._offset]
-        alpha_prod_t_prev = self.alphas_cumprod[timestep_prev + 1 - self._offset]
+        alpha_prod_t = state.alphas_cumprod[timestep + 1 - state._offset]
+        alpha_prod_t_prev = state.alphas_cumprod[timestep_prev + 1 - state._offset]
         beta_prod_t = 1 - alpha_prod_t
         beta_prod_t_prev = 1 - alpha_prod_t_prev
 

--- a/stable_diffusion_jax/scheduling_pndm.py
+++ b/stable_diffusion_jax/scheduling_pndm.py
@@ -14,7 +14,6 @@
 
 # DISCLAIMER: This file is strongly influenced by https://github.com/ermongroup/ddim
 
-from dataclasses import dataclass
 import math
 
 import jax


### PR DESCRIPTION
This is the biggest change derived from #5.

In that branch I was previously using a standard Python dataclass and a `dict` to manage the scheduler state, and I converted between them when needed. I have now adopted `flax.struct.dataclass`, which is essentially the same but:
- It's frozen so it enforces functional updates.
- Can be easily replicated across devices.

I'm not super happy with the result for these reasons:
- Invoking `scheduler.set_timesteps()` requires more information to initialize the state, such as the shape of the expected inputs. This makes the code a bit uglier because you need to prepare that in advance.
- The dataclass has many state vars. In PyTorch we initialized the instance with just the betas and the number of training steps, and then added a few items when setting the inference timesteps. If we try to do the same here by providing defaults to most attributes, then Python synthesizes an initializer with just the `betas` and the `num_training_steps`, and then the `replace` method doesn't work. I had to create a specific class method to simplify the initial creation of the instance.
- The updates in `step` are harder to follow than the PyTorch logic.

Note also that the initial PRK steps have not been implemented yet (since we are skipping them by default). If we go with this approach they should be easy to add.
